### PR TITLE
Fix spinloop in Proto::SSLEAY::print

### DIFF
--- a/lib/Net/Server/Proto/SSLEAY.pm
+++ b/lib/Net/Server/Proto/SSLEAY.pm
@@ -372,6 +372,7 @@ sub print {
     my $buf    = @_ == 1 ? $_[0] : join('', @_);
     my $ssl    = $client->SSLeay;
     while (length $buf) {
+        return 0 if ($client->eof());
         vec(my $vec = '', $client->fileno, 1) = 1;
         select(undef, $vec, undef, undef);
 


### PR DESCRIPTION
If the client becomes totally unresponsive, this code will attempt to send a 500/server error message about the header timeout. With a non-responsive client, this eventually times out, but 'print' keeps looping (select returns EAGAIN/EWOULDBLOCK), and it spinloops forever.

The fix adds a return if the client handle is at EOF.